### PR TITLE
Patched for CVE-2026-46633 - Encode single quotes as \x27 in Compiler…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://twig.symfony.com",
     "license": "BSD-3-Clause",
     "minimum-stability": "dev",
-    "version": "1.44.9",
+    "version": "1.44.10",
     "authors": [
         {
             "name": "Fabien Potencier",

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -159,8 +159,14 @@ class Compiler implements \Twig_CompilerInterface
      */
     public function string($value)
     {
-        $this->source .= sprintf('"%s"', addcslashes($value, "\0\t\"\$\\"));
-
+        // Single quotes are encoded as \x27 (not \') as a defense-in-depth measure:
+        // it guarantees that the compiled output never contains a literal "'" derived
+        // from user input, which prevents breaking out of a surrounding single-quoted
+        // PHP context if a caller mistakenly concatenates the result into one.
+        // \' is not a recognized escape sequence in PHP double-quoted strings (the
+        // backslash would be kept literally), so \x27 is used instead.
+        $this->source .= \sprintf('"%s"', str_replace("'", '\\x27', addcslashes($value, "\0\t\"\$\\")));
+        
         return $this;
     }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -13,6 +13,7 @@ namespace Twig\Tests;
 
 use Twig\Compiler;
 use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class CompilerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -16,6 +16,24 @@ use Twig\Environment;
 
 class CompilerTest extends \PHPUnit\Framework\TestCase
 {
+    public function testStringEncodesSingleQuotesAsHexEscape()
+    {
+        $compiler = new Compiler(new Environment(new ArrayLoader()));
+
+        // Defense in depth: a single quote in the source value must NOT appear as a
+        // literal "'" in the compiled output, so that even if a caller mistakenly
+        // concatenates the result into a single-quoted PHP string, the value cannot
+        // break out of that context. It must still decode back to the original byte.
+        $source = $compiler->string("it's \"a\" test")->getSource();
+
+        $this->assertStringNotContainsString("'", $source);
+        $this->assertSame('"it\\x27s \\"a\\" test"', $source);
+
+        $decoded = null;
+        eval('$decoded = '.$source.';');
+        $this->assertSame("it's \"a\" test", $decoded);
+    }
+
     public function testReprNumericValueWithLocale()
     {
         $compiler = new Compiler(new Environment($this->createMock('\Twig\Loader\LoaderInterface')));


### PR DESCRIPTION
## Description

Fixes CVE-2026-46633 by hardening `Compiler::string()` to escape single quotes when generating PHP string literals. Template names from `{% use %}` tags reach this method via `subcompile() → repr() → string()` and were previously placed inside surrounding single-quoted PHP literals in the compiled cache, so a name containing a single quote could break out of that context and inject arbitrary PHP, executing on cache load and bypassing the Twig sandbox. The fix now encodes any `'` in the value as the byte sequence `\x27` (rather than `\'`, which is not a valid escape inside PHP double-quoted strings and would corrupt the value), guaranteeing the output never contains a literal single quote derived from user input while still decoding back to the original string. The change bumps the version from 1.44.9 to 1.44.10 and adds a regression test in `CompilerTest.php` that asserts the encoded output contains no literal single quote and round-trips correctly via `eval()`.

---

Original patch: https://github.com/twigphp/Twig/commit/679447fa29083043665482ccf7d64372472621b8